### PR TITLE
utils-cli as a runtime dependency

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -33,6 +33,7 @@ Depends: libignition-transport10 (= ${binary:Version}),
          libignition-msgs7-dev,
          libignition-cmake2-dev,
          libignition-tools-dev,
+         libignition-utils1-cli-dev,
          libignition-utils1-dev,
          ${misc:Depends}
 Multi-Arch: same


### PR DESCRIPTION
This is needed to fix downstream warnings, see https://github.com/ignitionrobotics/ign-transport/pull/229#issuecomment-807925268

After Edifice we should revisit this, possibly for Fortress.